### PR TITLE
Add shebang line and make .py files executable.

### DIFF
--- a/segmenter/default.py
+++ b/segmenter/default.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env python2
 import sys, codecs, optparse, os
 
 optparser = optparse.OptionParser()

--- a/segmenter/score-segments.py
+++ b/segmenter/score-segments.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 from __future__ import division
 import optparse, sys, codecs
 from collections import defaultdict


### PR DESCRIPTION
This will allow users to run the files without having to type `python` every
time (at least for non-Windows users).
